### PR TITLE
Remove pricing functionality

### DIFF
--- a/models.py
+++ b/models.py
@@ -17,19 +17,9 @@ class CatalogItemSummary:
 
 
 @dataclass
-class PricingInfo:
-    """Container describing the pricing state of an ASIN."""
-
-    price: Optional[float]
-    currency: Optional[str]
-    source: str = ""
-
-
-@dataclass
 class LookupResult:
     """Result of an ASIN lookup for a specific EAN and marketplace."""
 
     ean: str
     marketplace: str
     item: CatalogItemSummary
-    pricing: Optional[PricingInfo]

--- a/paapi_client.py
+++ b/paapi_client.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from tenacity import RetryError, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from models import CatalogItemSummary, PricingInfo
+from models import CatalogItemSummary
 
 try:  # pragma: no cover - optional dependency
     from paapi5_python_sdk.api.default_api import DefaultApi
@@ -185,12 +185,6 @@ class PAAPIClient:
                     )
                 )
         return summaries
-
-    def get_featured_offer_price(self, asin: str, marketplace: str) -> Optional[PricingInfo]:
-        # PA-API already returns offer listings in the lookup response; pricing can be pulled separately.
-        # Since PA-API does not support retrieving pricing without an item lookup, this method returns None.
-        return None
-
 
 def create_client(env_path: str | Path = ".env") -> Optional[PAAPIClient]:
     credentials = load_credentials(env_path)

--- a/quick_match.py
+++ b/quick_match.py
@@ -107,8 +107,12 @@ def main(in_csv: str, out_csv: str, marketplaces: List[str]) -> None:
             items = _resp_items(resp)
             if not items:
                 out_rows.append({
-                    "ean": ean, "marketplace": m.upper(), "asin": "",
-                    "title": "", "brand": "", "pack_size": "", "current_sales_price": ""
+                    "ean": ean,
+                    "marketplace": m.upper(),
+                    "asin": "",
+                    "title": "",
+                    "brand": "",
+                    "pack_size": "",
                 })
                 continue
 
@@ -122,12 +126,14 @@ def main(in_csv: str, out_csv: str, marketplaces: List[str]) -> None:
                     "title": title,
                     "brand": brand,
                     "pack_size": pack_size_from_title(title),
-                    "current_sales_price": "",  # pricing skipped in this quick runner
                 })
 
     os.makedirs(os.path.dirname(out_csv) or ".", exist_ok=True)
     with open(out_csv, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=["ean","marketplace","asin","title","brand","pack_size","current_sales_price"])
+        w = csv.DictWriter(
+            f,
+            fieldnames=["ean", "marketplace", "asin", "title", "brand", "pack_size"],
+        )
         w.writeheader(); w.writerows(out_rows)
     print(f"✅ Wrote {len(out_rows)} rows to {out_csv}")
 

--- a/spapi_compat.py
+++ b/spapi_compat.py
@@ -18,18 +18,6 @@ def _pick_class(module_name, preferred_names, must_have_methods=()):
                 return obj
     raise ImportError(f"No suitable class found in {module_name} matching {preferred_names}")
 
-# ----- ProductPricing (optional) -----
-try:
-    ProductPricing = _pick_class(
-        "sp_api.api.product_pricing",
-        preferred_names=["ProductPricing", "ProductPricingV0", "ProductPricingV20200501"],
-        must_have_methods=("get_pricing",)
-    )
-except Exception:
-    class ProductPricing:  # harmless stub so imports/instantiation won't crash
-        def __init__(self, *_, **__): pass
-        def __getattr__(self, _): raise RuntimeError("ProductPricing not available in this sp_api build")
-
 # ----- CatalogItems (required) -----
 CatalogItems = None
 # try modern module first, then legacy aggregate, then older alias
@@ -46,4 +34,4 @@ for module in ("sp_api.api.catalog_items", "sp_api.api", "sp_api.api.catalog"):
 if CatalogItems is None:
     raise ImportError("Could not locate a usable CatalogItems class in sp_api")
 
-__all__ = ["ProductPricing", "CatalogItems"]
+__all__ = ["CatalogItems"]


### PR DESCRIPTION
## Summary
- remove pricing lookup controls from the matcher CLI and web UI so no pricing calls are made
- drop the unused pricing dataclasses and helpers from the Amazon client wrappers
- align quick_match CSV output with the reduced column set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64dce7ce48325824c1b8c6045fb47