### PR TITLE
Persist webapp job state across workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ logs/
 data/
 output/
 logs/
+job_state/
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- persist job state to disk so progress polling works across multiple workers
- fall back to loading job metadata from disk for progress and downloads and ignore runtime artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6547c9eac8325a71c9f4d6918b72f