### PR TITLE
Fix SP-API client instantiation and improve quick match pack size parsing

### DIFF
--- a/spapi_client.py
+++ b/spapi_client.py
@@ -214,14 +214,10 @@ class SPAPIClient:
             if client is None:
                 credentials_dict = self.credentials.to_dict()
                 marketplace = self._get_marketplace(marketplace_code)
-                client_kwargs = {
-                    "marketplace": marketplace,
-                    "credentials": credentials_dict,
-                }
-                marketplace_region = getattr(marketplace, "region", None)
-                if marketplace_region:
-                    client_kwargs["region"] = marketplace_region
-                client = CatalogItems(**client_kwargs)
+                client = CatalogItems(
+                    marketplace=marketplace,
+                    credentials=credentials_dict,
+                )
                 self._catalog_clients[marketplace_code] = client
         return client
 


### PR DESCRIPTION
## Summary
- remove legacy region parameter when instantiating CatalogItems clients and continue using the marketplace enum
- expand quick_match marketplace mapping and reuse structured pack size data before falling back to title heuristics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e66adc6648832590f286538736a3c8