### PR TITLE
Refine catalog search variants to avoid invalid parameters

### DIFF
--- a/spapi_client.py
+++ b/spapi_client.py
@@ -269,28 +269,17 @@ class SPAPIClient:
         ean: str,
     ) -> Dict[str, Any]:
         marketplace_id = self._get_marketplace(marketplace).marketplace_id
+        ean_value = str(ean).strip()
+        if not ean_value:
+            return {}
+
         variants = [
             {
-                "identifiers": [ean],
-                "identifiersType": "EAN",
-                "includedData": ["summaries", "identifiers", "attributes"],
-            },
-            {
-                "identifiers": ean,
-                "identifiersType": "EAN",
-                "includedData": ["summaries", "identifiers", "attributes"],
-            },
-            {
-                "identifiers": [ean],
+                "identifiers": [ean_value],
                 "identifiersType": "EAN",
             },
-            {
-                "identifiers": ean,
-                "identifiersType": "EAN",
-            },
-            {"keywords": [ean]},
-            {"keywords": ean},
-            {"query": ean},
+            {"keywords": [ean_value]},
+            {"query": ean_value},
         ]
 
         last_exc: Optional[SellingApiException] = None


### PR DESCRIPTION
## Summary
- normalize the requested EAN value before making SP-API catalog calls
- drop unsupported includeData/keywords string variants to avoid noisy InvalidInput warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7b5cc70408325a833dda0d4f2e588