### PR TITLE
Add color, size, and number_of_items columns to export

### DIFF
--- a/tests/test_amazon_ean_matcher.py
+++ b/tests/test_amazon_ean_matcher.py
@@ -1,0 +1,26 @@
+from amazon_ean_matcher import extract_attribute_value
+
+
+def test_extract_attribute_value_direct_string():
+    attributes = {"Color": "Blue"}
+    assert extract_attribute_value(attributes, ("color",)) == "Blue"
+
+
+def test_extract_attribute_value_nested_mapping():
+    attributes = {"ProductInfo": {"SizeName": {"value": "Large"}}}
+    assert extract_attribute_value(attributes, ("size", "size_name", "sizename")) == "Large"
+
+
+def test_extract_attribute_value_sequence():
+    attributes = {
+        "Details": [
+            {"NumberOfItems": {"Values": ["24"]}},
+            {"Fallback": "ignore"},
+        ]
+    }
+    assert extract_attribute_value(attributes, ("number_of_items", "numberofitems")) == "24"
+
+
+def test_extract_attribute_value_missing():
+    attributes = {"SomethingElse": "value"}
+    assert extract_attribute_value(attributes, ("color",)) is None


### PR DESCRIPTION
## Summary
- include color, size, and number_of_items in the generated CSV export
- add a reusable helper that extracts nested attribute values from Amazon API responses
- cover the helper with unit tests for direct, nested, and list-based attribute structures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e7bd3f2f608325bcc753cdadff1b2f